### PR TITLE
Close files when raising ApplicationError

### DIFF
--- a/burrito/util.py
+++ b/burrito/util.py
@@ -277,11 +277,12 @@ class CommandLineApplication(Application):
         # Determine if error should be raised due to exit status of
         # appliciation
         if not self._accept_exit_status(exit_status):
-            raise ApplicationError('Unacceptable application exit ' +
-                                   'status: %s\n' % str(exit_status) +
-                                   'Command:\n%s\n' % command +
-                                   'StdOut:\n%s\n' % open(outfile).read() +
-                                   'StdErr:\n%s\n' % open(errfile).read())
+            with open(outfile) as out, open(errfile) as err:
+                raise ApplicationError('Unacceptable application exit ' +
+                                       'status: %s\n' % str(exit_status) +
+                                       'Command:\n%s\n' % command +
+                                       'StdOut:\n%s\n' % out.read() +
+                                       'StdErr:\n%s\n' % err.read())
 
         # open the stdout and stderr if not being suppressed
         out = None


### PR DESCRIPTION
This causes annoying warnings of following when trying to catch exception the in the test (https://github.com/biocore/micronota/pull/4/files#diff-f4634973ce329c1911a2e7af8c7b2238R66):

/Users/zech/anaconda/envs/py3/lib/python3.4/site-packages/burrito/util.py:284: ResourceWarning: unclosed file <_io.TextIOWrapper name='/var/folders/4f/5zc7djg954dc71r037j88jwh0000gn/T/tmpVNv0QHOevYp34Cj
dqm1J.txt' mode='r' encoding='UTF-8'>
